### PR TITLE
Add Ltning / floppy.museum

### DIFF
--- a/members.json
+++ b/members.json
@@ -61,5 +61,9 @@
 		"id": "VE3ZSH",
 		"url": "https://ve3zsh.ca/webrings/index.html",
 		"rss": "https://ve3zsh.ca/til/index.xml"
+	},
+	{
+		"id": "Ltning",
+		"url": "http://floppy.museum/thispc.htm"
 	}
 ]


### PR DESCRIPTION
The Floppy Museum is a 286 running a website (http://floppy.museum) and a bunch of other stuff*. From a floppy.

* An IRC server, a bulletin board, and an FTP server so I could update the site with this new webring from another country. :)